### PR TITLE
Fix build issue on MACOS 10.15.7

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-boost/1.71.0@conan/stable
+boost/1.71.0
 
 [generators]
 cmake


### PR DESCRIPTION
### Env
macOS Catalina v10.15.7
Conan v1.30.1
CMake v3.18.4

### Scenario
1. Run configure.sh script

### Result
Error in console
```
../gzlib.c:252:9: error: implicit declaration of function 'lseek' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        LSEEK(state->fd, 0, SEEK_END);  /* so gzoffset() is correct */
        ^
../gzlib.c:14:17: note: expanded from macro 'LSEEK'
#  define LSEEK lseek
                ^
../gzlib.c:252:9: note: did you mean 'fseek'?
../gzlib.c:14:17: note: expanded from macro 'LSEEK'
#  define LSEEK lseek
                ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:162:6: note: 
      'fseek' declared here
int      fseek(FILE *, long, int);
         ^
../gzlib.c:258:24: error: implicit declaration of function 'lseek' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        state->start = LSEEK(state->fd, 0, SEEK_CUR);
                       ^
../gzlib.c:14:17: note: expanded from macro 'LSEEK'
#  define LSEEK lseek
                ^
../gzlib.c:359:9: error: implicit declaration of function 'lseek' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    if (LSEEK(state->fd, state->start, SEEK_SET) == -1)
        ^
../gzlib.c:14:17: note: expanded from macro 'LSEEK'
#  define LSEEK lseek
                ^
../gzlib.c:400:15: error: implicit declaration of function 'lseek' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        ret = LSEEK(state->fd, offset - state->x.have, SEEK_CUR);
              ^
../gzlib.c:14:17: note: expanded from macro 'LSEEK'
#  define LSEEK lseek
                ^
../gzlib.c:496:14: error: implicit declaration of function 'lseek' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    offset = LSEEK(state->fd, 0, SEEK_CUR);
             ^
../gzlib.c:14:17: note: expanded from macro 'LSEEK'
#  define LSEEK lseek
                ^
5 errors generated.
make: *** [gzlib.o] Error 1
make: *** Waiting for unfinished jobs....
zlib/1.2.11@conan/stable: 
zlib/1.2.11@conan/stable: ERROR: Package '647afeb69d3b0a2d3d316e80b24d38c714cc6900' build failed
zlib/1.2.11@conan/stable: WARN: Build folder /Users/vladislavvoinov/.conan/data/zlib/1.2.11/conan/stable/build/647afeb69d3b0a2d3d316e80b24d38c714cc6900
ERROR: zlib/1.2.11@conan/stable: Error in build() method, line 59
	self._build_zlib()
while calling '_build_zlib', line 108
	self._build_zlib_autotools()
while calling '_build_zlib_autotools', line 81
	env_build.make(target=make_target)
	ConanException: Error 2 while executing make libz.a -j4
-- The C compiler identification is AppleClang 12.0.0.12000032
-- The CXX compiler identification is AppleClang 12.0.0.12000032
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Error at CMakeLists.txt:9 (include):
  include could not find load file:

    /Users/vladislavvoinov/xcodeprojects/boost_optional_ext/Build/conanbuildinfo.cmake


CMake Error at CMakeLists.txt:10 (conan_basic_setup):
  Unknown CMake command "conan_basic_setup".


-- Configuring incomplete, errors occurred!
```

### Similar issue
https://github.com/bincrafters/community/issues/1160

### Solution
Change Boost version to boost/1.71.0 