### PR TITLE
Fix configure task

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: configure
-      run: ./configure
+      run: sh ./configure.sh
     - name: make
       run: make
     - name: make check


### PR DESCRIPTION
### Problem
CI fails with error
```
Run ./configure
4
/home/runner/work/_temp/7f3c22ac-bb4c-402f-9e61-d2026279dade.sh: line 1: ./configure: No such file or directory
5
Error: Process completed with exit code 127.
```

### Solution
- Use "sh" command to avoid permission issues;
- Locate configure file properly;