### PR TITLE
Use BOOST_REQUIRE_MESSAGE for tests

### DIFF
--- a/tests/test_hof.cpp
+++ b/tests/test_hof.cpp
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_CASE(case_filter_if_Accepted)
 
     const auto res = toRefOp(op) | hof::filter_if(([](auto&& el) { return !el.empty(); }));
 
-    BOOST_CHECK_EQUAL(res.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(res.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(res.get(), op.get());
     BOOST_CHECK_EQUAL(res.get_ptr(), op.get_ptr());
 }
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(case_filter_if_NotAccepted)
 
     const auto res = toRefOp(op) | hof::filter_if(([](auto&& el) { return el.empty(); }));
 
-    BOOST_CHECK_EQUAL(res.has_value(), false);
+    BOOST_REQUIRE_MESSAGE(!res.has_value(), "boost::optional has a value!");
 }
 
 BOOST_AUTO_TEST_CASE(case_filter_if_not_Accepted)
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(case_filter_if_not_Accepted)
 
     const auto res = toRefOp(op) | hof::filter_if_not(([](auto&& el) { return el.empty(); }));
 
-    BOOST_CHECK_EQUAL(res.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(res.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(res.get(), op.get());
     BOOST_CHECK_EQUAL(res.get_ptr(), op.get_ptr());
 }
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(case_filter_if_not_NotAccepted)
 
     const auto res = toRefOp(op) | hof::filter_if_not(([](auto&& el) { return !el.empty(); }));
 
-    BOOST_CHECK_EQUAL(res.has_value(), false);
+    BOOST_REQUIRE_MESSAGE(!res.has_value(), "boost::optional has a value!");
 }
 
 BOOST_AUTO_TEST_CASE(case_filter_if_not_not_const_Accepted)
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(case_filter_if_not_not_const_Accepted)
 
     auto res = toRefOp(op) | hof::filter_if_not(([](auto&& el) { return el.empty(); }));
 
-    BOOST_CHECK_EQUAL(res.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(res.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(res.get(), op.get());
     BOOST_CHECK_EQUAL(res.get_ptr(), op.get_ptr());
 }
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(case_match_some)
      | hof::match_some(log)
     ;
 
-    BOOST_CHECK_EQUAL(res.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(res.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(strLen, std::get<1>(*res).size());
 }
 
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE(case_match_some_none)
      | hof::match(some, none)
     ;
 
-    BOOST_CHECK_EQUAL(res.has_value(), false);
+    BOOST_REQUIRE_MESSAGE(!res.has_value(), "boost::optional has a value!");
     BOOST_CHECK_EQUAL(isNone, true);
 }
 
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(case_match_some_2)
      | hof::filter_if(isPositive)
      | hof::match_some(some);
 
-    BOOST_CHECK_EQUAL(res.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(res.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(isSome, true);
 }
 

--- a/tests/test_optional_ext.cpp
+++ b/tests/test_optional_ext.cpp
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(Test_rv_tr_IsNotApplied)
         }
     };
 
-    BOOST_CHECK_EQUAL(res.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(res.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(res.get(), originValue);
     BOOST_CHECK(res.get() != 1000);
 }
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(Test_lv_tr_IsNotApplied)
 
     auto res = op | lv_tr;
 
-    BOOST_CHECK_EQUAL(res.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(res.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(res.get(), originValue);
     BOOST_CHECK(res.get() != 1000);
 }
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE(Test_rv_tr_IsApplied)
         }
     };
 
-    BOOST_CHECK_EQUAL(res.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(res.has_value(), "boost::optional has no value!");
     BOOST_CHECK(res.get() != originValue);
     BOOST_CHECK_EQUAL(res.get(), newValue);
 }
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(Test_lv_tr_IsApplied)
 
     auto res = op | lv_tr;
 
-    BOOST_CHECK_EQUAL(res.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(res.has_value(), "boost::optional has no value!");
     BOOST_CHECK(res.get() != originValue);
     BOOST_CHECK_EQUAL(res.get(), newValue);
 }
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(Test_rvOp_rvTr_lvTr)
     //         rv optional             | rv tr                                       | lv tr
     auto res = boost::optional<int>(1) | [](const auto& value) { return value + 1; } | lv_Tr;
 
-    BOOST_CHECK_EQUAL(res.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(res.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(res.get(), 4);
 }
 
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(Test_rvOp_lvTr_rvTr)
     //         rv optional             | lv tr | rv tr
     auto res = boost::optional<int>(1) | lv_Tr | [](const auto& value) { return value + 1; };
 
-    BOOST_CHECK_EQUAL(res.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(res.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(res.get(), 3);
 }
 
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE(Test_lvOp_rvTr_lvTr)
     //          lv optional | rv tr                                       | lv tr
     auto res = /*   */ lvOp | [](const auto& value) { return value + 1; } | lv_Tr;
 
-    BOOST_CHECK_EQUAL(res.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(res.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(res.get(), 4);
 }
 
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(Test_lvOp_lvTr_rvTr)
     //         lv optional | lv tr | rv tr
     auto res = /*  */ lvOp | lv_Tr | [](const auto& value) { return value + 1; };
 
-    BOOST_CHECK_EQUAL(res.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(res.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(res.get(), 3);
 }
 
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE(Test_lvOp_lvTr_rvTr_equal_references)
     //         lv optional | lv tr | rv tr
     auto res = /*  */ lvOp | lv_Tr | [](auto& value) { return boost::optional<int&>(value); };
 
-    BOOST_CHECK_EQUAL(res.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(res.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(res.get(), 1);
     BOOST_CHECK_EQUAL(&lvOp.get(), &res.get());
 }
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE(Test_lvOp_lvTr_rvTr_equal_const_references)
     //         lv optional | lv tr | rv tr
     auto res = /*  */ lvOp | lv_Tr | [](const auto& value) { return boost::optional<const int&>(value); };
 
-    BOOST_CHECK_EQUAL(res.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(res.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(res.get(), 1);
     BOOST_CHECK_EQUAL(&lvOp.get(), &res.get());
 }
@@ -204,7 +204,7 @@ BOOST_AUTO_TEST_CASE(Test_lvOp_lvTr_rvTr_not_equal_references_when_ret_as_value)
     //         lv optional | lv tr | rv tr
     auto res = /*  */ lvOp | lv_Tr | [](const auto& value) { return value; };
 
-    BOOST_CHECK_EQUAL(res.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(res.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(res.get(), 1);
     BOOST_CHECK(&lvOp.get() != &res.get());
 }
@@ -218,7 +218,7 @@ BOOST_AUTO_TEST_CASE(Test_lvOp_lvTr_rvTr_not_equal_references_when_ret_as_option
     //         lv optional | lv tr | rv tr
     auto res = /*  */ lvOp | lv_Tr | [](const auto& value) { return boost::optional<int>(value); };
 
-    BOOST_CHECK_EQUAL(res.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(res.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(res.get(), 1);
     BOOST_CHECK(&lvOp.get() != &res.get());
 }
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE(Test_rvOp_rvFt_check_str_is_true_negative_case)
     const std::string str = "false";
     auto lv_op = boost::make_optional(str) | [](const auto& el) { return boost::make_optional(el == "true", true); };
 
-    BOOST_CHECK_EQUAL(lv_op.has_value(), false);
+    BOOST_REQUIRE_MESSAGE(!lv_op.has_value(), "boost::optional has a value!");
 }
 
 BOOST_AUTO_TEST_CASE(Test_rvOp_rvFt_check_str_is_true_positive_case)
@@ -236,7 +236,7 @@ BOOST_AUTO_TEST_CASE(Test_rvOp_rvFt_check_str_is_true_positive_case)
     const std::string str = "true";
     auto lv_op = boost::make_optional(str) | [](const auto& el) { return boost::make_optional(el == "true", true); };
 
-    BOOST_CHECK_EQUAL(lv_op.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(lv_op.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(lv_op.get(), true);
 }
 
@@ -246,7 +246,7 @@ BOOST_AUTO_TEST_CASE(Test_convert_int_to_str)
     auto lv_op_positive_case = boost::make_optional(1) | lv_ft_tr;
     auto lv_op_negatie_case = boost::make_optional(-1) | lv_ft_tr;
 
-    BOOST_CHECK_EQUAL(lv_op_positive_case.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(lv_op_positive_case.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(lv_op_positive_case.get(), "+1");
     BOOST_CHECK_EQUAL(lv_op_negatie_case.has_value(), false);
 }
@@ -256,7 +256,7 @@ BOOST_AUTO_TEST_CASE(Test_convert_int_to_str_with_return_def_value)
     auto lv_ft_tr = [](const auto& el) { return boost::make_optional(el > 0, "+" + std::to_string(el)); };
     auto lv_op = boost::make_optional(-1) | lv_ft_tr |= []() -> std::string { return "not a positive number"; };
 
-    BOOST_CHECK_EQUAL(lv_op.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(lv_op.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(lv_op.get(), "not a positive number");
 }
 
@@ -267,7 +267,7 @@ BOOST_AUTO_TEST_CASE(Test_convert_int_to_str_with_no_value_from_external_service
     auto lv_ft_tr = [](const auto& el) { return boost::make_optional(el > 0, "+" + std::to_string(el)); };
     auto lv_op = boost::make_optional(-1) | lv_ft_tr |= [externalService = askValueFromMoon]() { return boost::make_optional<std::string>(externalService(), "default value"); };
 
-    BOOST_CHECK_EQUAL(lv_op.has_value(), false);
+    BOOST_REQUIRE_MESSAGE(!lv_op.has_value(), "boost::optional has a value!");
 }
 
 BOOST_AUTO_TEST_CASE(Test_convert_int_to_str_with_value_from_external_service)
@@ -277,7 +277,7 @@ BOOST_AUTO_TEST_CASE(Test_convert_int_to_str_with_value_from_external_service)
     auto lv_ft_tr = [](const auto& el) { return boost::make_optional(el > 0, "+" + std::to_string(el)); };
     auto lv_op = boost::make_optional(-1) | lv_ft_tr |= [externalService = askValueFromMoon]() { return boost::make_optional<std::string>(externalService(), "default value"); };
 
-    BOOST_CHECK_EQUAL(lv_op.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(lv_op.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(lv_op.get(), "default value");
 }
 
@@ -325,7 +325,7 @@ BOOST_AUTO_TEST_CASE(Test_std_function)
 
     auto op = boost::make_optional(1000) | stdFun;
 
-    BOOST_CHECK_EQUAL(op.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(op.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(op.get(), 0);
 }
 
@@ -338,7 +338,7 @@ BOOST_AUTO_TEST_CASE(Test_free_fn)
 {
     auto op = boost::make_optional(1000) | freeFn;
 
-    BOOST_CHECK_EQUAL(op.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(op.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(op.get(), 0);
 }
 
@@ -364,7 +364,7 @@ BOOST_AUTO_TEST_CASE(Test_std_bind)
 
     auto op = boost::make_optional(1) | std::bind(&TestClass::action, &task, std::placeholders::_1);
 
-    BOOST_CHECK_EQUAL(op.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(op.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(op.get(), 10);
 }
 
@@ -381,7 +381,7 @@ BOOST_AUTO_TEST_CASE(Test_static_method)
 
     auto op = boost::make_optional(1) | TestClass::action;
 
-    BOOST_CHECK_EQUAL(op.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(op.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(op.get(), 0);
 }
 
@@ -395,7 +395,7 @@ BOOST_AUTO_TEST_CASE(Test_template_fn_with_instantiation)
 {
     auto op = boost::make_optional(1) | freeTmplFn<int>;
 
-    BOOST_CHECK_EQUAL(op.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(op.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(op.get(), "1");
 }
 

--- a/tests/test_optional_ext_with_const.cpp
+++ b/tests/test_optional_ext_with_const.cpp
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(std_function)
 
     auto op = cOp | stdFun;
 
-    BOOST_CHECK_EQUAL(op.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(op.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(op.get(), 0);
 }
 
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(free_fn)
     const auto cOp = boost::make_optional(1); 
     auto op = cOp | freeFn;
 
-    BOOST_CHECK_EQUAL(op.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(op.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(op.get(), 0);
 }
 
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE(std_bind)
 
     auto op = cOp | std::bind(&TestClass::action, &task, std::placeholders::_1);
 
-    BOOST_CHECK_EQUAL(op.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(op.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(op.get(), 10);
 }
 
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(static_method)
     const auto cOp = boost::make_optional(1); 
     auto op = cOp | TestClass::action;
 
-    BOOST_CHECK_EQUAL(op.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(op.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(op.get(), 0);
 }
 
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(template_fn_with_instantiation)
     const auto cOp = boost::make_optional(1); 
     auto op =  cOp | freeTmplFn<int>;
 
-    BOOST_CHECK_EQUAL(op.has_value(), true);
+    BOOST_REQUIRE_MESSAGE(op.has_value(), "boost::optional has no value!");
     BOOST_CHECK_EQUAL(op.get(), "1");
 }
 


### PR DESCRIPTION
Use BOOST_REQUIRE_MESSAGE for the Boost optional check to not crash test suite in case of empty optional;